### PR TITLE
RDataFrame incorporation (WIP)

### DIFF
--- a/Analysis/TreeFilter/RecoResonance/scripts/Conf2016.py
+++ b/Analysis/TreeFilter/RecoResonance/scripts/Conf2016.py
@@ -883,7 +883,7 @@ def build_truth( args ) :
 
     truth_filt = Filter('BuildTruth')
 
-    truth_filt.cut_lep_mother = ' == 24 || == -24 ||  == 11 || == -11 || == 12 || == -12 || == 13 || == -13 || == 14 || == -14 || == 15 || == -15 || == 16 || == -16 '
+    truth_filt.cut_lep_mother = ' == 23 || == -23 || == 24 || == -24 ||  == 11 || == -11 || == 12 || == -12 || == 13 || == -13 || == 14 || == -14 || == 15 || == -15 || == 16 || == -16 '
     #truth_filt.cut_lep_status = ' != 23 '
 
     truth_filt.cut_ph_pt = ' > 5 '

--- a/Analysis/TreeFilter/RecoResonance/scripts/Conf2017.py
+++ b/Analysis/TreeFilter/RecoResonance/scripts/Conf2017.py
@@ -885,7 +885,7 @@ def build_truth( args ) :
 
     truth_filt = Filter('BuildTruth')
 
-    truth_filt.cut_lep_mother = ' == 24 || == -24 ||  == 11 || == -11 || == 12 || == -12 || == 13 || == -13 || == 14 || == -14 || == 15 || == -15 || == 16 || == -16 '
+    truth_filt.cut_lep_mother = ' == 23 || == -23 || == 24 || == -24 ||  == 11 || == -11 || == 12 || == -12 || == 13 || == -13 || == 14 || == -14 || == 15 || == -15 || == 16 || == -16 '
     #truth_filt.cut_lep_status = ' != 23 '
 
     truth_filt.cut_ph_pt = ' > 5 '

--- a/Analysis/TreeFilter/RecoResonance/scripts/Conf2018.py
+++ b/Analysis/TreeFilter/RecoResonance/scripts/Conf2018.py
@@ -886,7 +886,7 @@ def build_truth( args ) :
 
     truth_filt = Filter('BuildTruth')
 
-    truth_filt.cut_lep_mother = ' == 24 || == -24 ||  == 11 || == -11 || == 12 || == -12 || == 13 || == -13 || == 14 || == -14 || == 15 || == -15 || == 16 || == -16 '
+    truth_filt.cut_lep_mother = ' == 23 || == -23 ||  == 24 || == -24 ||  == 11 || == -11 || == 12 || == -12 || == 13 || == -13 || == 14 || == -14 || == 15 || == -15 || == 16 || == -16 '
     #truth_filt.cut_lep_status = ' != 23 '
 
     truth_filt.cut_ph_pt = ' > 5 '

--- a/Plotting/Modules/Resonance2016.py
+++ b/Plotting/Modules/Resonance2016.py
@@ -28,10 +28,12 @@ def config_samples(samples) :
 
     samples.AddSample('TTJets_SingleLeptFromTbar',
                       path='TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      #path='TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
                       isActive=False, useXSFile=True )
 
     samples.AddSample('TTJets_SingleLeptFromT',
                       path='TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      #path='TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
                       isActive=False, useXSFile=True )
 
     samples.AddSample('TTGJets',
@@ -68,7 +70,7 @@ def config_samples(samples) :
                       isActive=False, useXSFile=True, plotColor=ROOT.kOrange, XSName='WGToLNuG-amcatnloFXFX')
 
     samples.AddSample('WGToLNuG_PtG-130-amcatnloFXFXPhCut',
-                      path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutMaxPhCutMin',
+                      path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutRange',
                       #path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutMaxPhCutMin',
                       isActive=False, useXSFile=True, plotColor=ROOT.kViolet, XSName='WGToLNuG_PtG-130-amcatnloFXFX' )
 
@@ -201,7 +203,7 @@ def config_samples(samples) :
 
     samples.AddSample('MadGraphResonanceMass200_width0p01', path='MadGraphChargedResonance_WGToLNu_M200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kCyan, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 200 GeV', XSName='ResonanceMass200')
     samples.AddSample('MadGraphResonanceMass200_width5', path='MadGraphChargedResonance_WGToLNu_M200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 200 GeV', XSName='ResonanceMass200')
-    #samples.AddSample('MadGraphResonanceMass250_width0p01', path='MadGraphChargedResonance_WGToLNu_M250_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kYellow, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250') ## TODO ACTIVE SIGNAL
+    samples.AddSample('MadGraphResonanceMass250_width0p01', path='MadGraphChargedResonance_WGToLNu_M250_width0p01', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kPink-1, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250') ## TODO ACTIVE SIGNAL
     samples.AddSample('MadGraphResonanceMass250_width5', path='MadGraphChargedResonance_WGToLNu_M250_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250')
     samples.AddSample('MadGraphResonanceMass300_width0p01', path='MadGraphChargedResonance_WGToLNu_M300_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = 'M(#Phi^{#pm}) = 300 GeV', XSName='ResonanceMass300') #
     samples.AddSample('MadGraphResonanceMass300_width5', path='MadGraphChargedResonance_WGToLNu_M300_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 300 GeV', XSName='ResonanceMass300')
@@ -221,14 +223,14 @@ def config_samples(samples) :
     samples.AddSample('MadGraphResonanceMass800_width5', path='MadGraphChargedResonance_WGToLNu_M800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 800 GeV', XSName='ResonanceMass800')
     samples.AddSample('MadGraphResonanceMass900_width0p01', path='MadGraphChargedResonance_WGToLNu_M900_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 900 GeV', XSName='ResonanceMass900')
     samples.AddSample('MadGraphResonanceMass900_width5', path='MadGraphChargedResonance_WGToLNu_M900_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 900 GeV', XSName='ResonanceMass900')
-    samples.AddSample('MadGraphResonanceMass1000_width0p01', path='MadGraphChargedResonance_WGToLNu_M1000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000')
+    samples.AddSample('MadGraphResonanceMass1000_width0p01', path='MadGraphChargedResonance_WGToLNu_M1000_width0p01', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kPink+10, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000') ##TODO ACTIVE SIGNAL
     samples.AddSample('MadGraphResonanceMass1000_width5', path='MadGraphChargedResonance_WGToLNu_M1000_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000')
     samples.AddSample('MadGraphResonanceMass1200_width0p01', path='MadGraphChargedResonance_WGToLNu_M1200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1200 GeV', XSName='ResonanceMass1200')
     samples.AddSample('MadGraphResonanceMass1200_width5', path='MadGraphChargedResonance_WGToLNu_M1200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1200 GeV', XSName='ResonanceMass1200')
     samples.AddSample('MadGraphResonanceMass1400_width0p01', path='MadGraphChargedResonance_WGToLNu_M1400_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1400 GeV', XSName='ResonanceMass1400')
     samples.AddSample('MadGraphResonanceMass1400_width5', path='MadGraphChargedResonance_WGToLNu_M1400_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1400 GeV', XSName='ResonanceMass1400')
     samples.AddSample('MadGraphResonanceMass1600_width0p01', path='MadGraphChargedResonance_WGToLNu_M1600_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1600 GeV', XSName='ResonanceMass1600')
-    #samples.AddSample('MadGraphResonanceMass1600_width5', path='MadGraphChargedResonance_WGToLNu_M1600_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1600 GeV', XSName='ResonanceMass1600') ## TODO ACTIVE SIGNAL
+    samples.AddSample('MadGraphResonanceMass1600_width5', path='MadGraphChargedResonance_WGToLNu_M1600_width5', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1600 GeV', XSName='ResonanceMass1600') ## TODO ACTIVE SIGNAL
     samples.AddSample('MadGraphResonanceMass1800_width0p01', path='MadGraphChargedResonance_WGToLNu_M1800_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1800 GeV', XSName='ResonanceMass1800')
     samples.AddSample('MadGraphResonanceMass1800_width5', path='MadGraphChargedResonance_WGToLNu_M1800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1800 GeV', XSName='ResonanceMass1800')
     samples.AddSample('MadGraphResonanceMass2000_width0p01', path='MadGraphChargedResonance_WGToLNu_M2000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kGreen, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2000 GeV', XSName='ResonanceMass2000')
@@ -321,7 +323,7 @@ def config_samples(samples) :
     samples.AddSampleGroup(  'Zgamma', legend_name='Z#gamma',
                            input_samples = ['ZGTo2LG'],
                            plotColor = ROOT.kRed-8,
-                           isActive=False
+                           isActive=True
                           )
 
     samples.AddSampleGroup(  'Z+jetsLO', legend_name='Z+JetsLO',
@@ -331,8 +333,8 @@ def config_samples(samples) :
                           )
 
     samples.AddSampleGroup(  'Z+jets', legend_name='Z+Jets',
-                           #input_samples = ['DYJetsToLL_M-50-amcatnloFXFXPhOlap'],
-                           input_samples = ['DYJetsToLL_M-50-amcatnloFXFX'],
+                           input_samples = ['DYJetsToLL_M-50-amcatnloFXFXPhOlap'],
+                           #input_samples = ['DYJetsToLL_M-50-amcatnloFXFX'],
                            plotColor = ROOT.kCyan-5,
                           )
 
@@ -416,19 +418,19 @@ def config_samples(samples) :
     samples.AddSampleGroup( 'TTbar_DiLep', legend_name='t#bar{t} dileptonic',
                            input_samples = ['TTJets_DiLept'],
                            plotColor = ROOT.kMagenta+2,
-                           isActive=False,
+                           isActive=True,
                           )
 
     samples.AddSampleGroup( 'TTbar_SingleLep', legend_name='t#bar{t} semileptonic',
                            input_samples = ['TTJets_SingleLeptFromTbar', 'TTJets_SingleLeptFromT'],
                            plotColor = ROOT.kGreen+2,
-                           isActive=False,
+                           isActive=True,
                           )
 
     samples.AddSampleGroup( 'AllTop', legend_name='t#bar{t}',
                            input_samples = ['TTbar_DiLep', 'TTbar_SingleLep'],
                            plotColor = ROOT.kGreen+3,
-                           isActive=True,
+                           isActive=False,
                           )
 
     samples.AddSampleGroup( 'TopW', legend_name='tW',

--- a/Plotting/Modules/Resonance2016_efake.py
+++ b/Plotting/Modules/Resonance2016_efake.py
@@ -1,0 +1,480 @@
+def config_samples(samples) :
+
+    import ROOT
+
+    samples.AddSample('SingleMuon'                       , path='SingleMuon'    ,  isActive=False, isData = True)
+    samples.AddSample('SingleElectron'                       , path='SingleElectron'    ,  isActive=False, isData = True)
+
+    samples.AddSample('DYJetsToLL_M-50',
+                      path='DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('DYJetsToLL_M-50-amcatnloFXFXPhOlap',
+                      path='DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhOlap',
+                      isActive=False, useXSFile=True,XSName='DYJetsToLL_M-50-amcatnloFXFX' )
+
+    samples.AddSample('DYJetsToLL_M-50-amcatnloFXFX',
+                      path='DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('ZGTo2LG',
+                      path='ZGTo2LG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('TTJets_DiLept',
+                      path='TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      #path='TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('TTJets_SingleLeptFromTbar',
+                      path='TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      #path='TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('TTJets_SingleLeptFromT',
+                      path='TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      #path='TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('TTGJets',
+                      path='TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('WGToLNuG-amcatnloFXFX',
+                      path='WGToLNuG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kOrange )
+
+    samples.AddSample('WGToLNuG-madgraphMLM',
+                      path='WGToLNuG_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kOrange )
+
+    samples.AddSample('WGToLNuG_PtG-130-amcatnloFXFX',
+                      path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kViolet )
+
+    samples.AddSample('WGToLNuG_PtG-130-madgraphMLM',
+                      path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kViolet )
+
+    samples.AddSample('WGToLNuG_PtG-500-amcatnloFXFX',
+                      path='WGToLNuG_PtG-500_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kCyan   )
+
+    samples.AddSample('WGToLNuG_PtG-500-madgraphMLM',
+                      path='WGToLNuG_PtG-500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kCyan   )
+
+    samples.AddSample('WGToLNuG-amcatnloFXFXPhCut',
+                      path='WGToLNuG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutRange',
+                      #path='WGToLNuG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutMax',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kOrange, XSName='WGToLNuG-amcatnloFXFX')
+
+    samples.AddSample('WGToLNuG_PtG-130-amcatnloFXFXPhCut',
+                      path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutMaxPhCutMin',
+                      #path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutMaxPhCutMin',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kViolet, XSName='WGToLNuG_PtG-130-amcatnloFXFX' )
+
+    samples.AddSample('WGToLNuG_PtG-500-amcatnloFXFXPhCut',
+                      path='WGToLNuG_PtG-500_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutMin',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kCyan, XSName='WGToLNuG_PtG-500-amcatnloFXFX'   )
+
+    samples.AddSample('WGToLNuG-madgraphMLMPhCut',
+                      path='WGToLNuG_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhCutMax',
+                      #path='WGToLNuG_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhCutMax',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kOrange, XSName='WGToLNuG-madgraphMLM' )
+
+    samples.AddSample('WGToLNuG_PtG-130-madgraphMLMPhCut',
+                      path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhCutMaxPhCutMin',
+                      #path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhCutMaxPhCutMin',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kViolet, XSName='WGToLNuG_PtG-130-madgraphMLM' )
+
+    samples.AddSample('WGToLNuG_PtG-500-madgraphMLMPhCut',
+                      path='WGToLNuG_PtG-500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhCutMin',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kCyan , XSName='WGToLNuG_PtG-500-madgraphMLM'  )
+
+    samples.AddSample('WGToLNuG-madgraphMLMMTResCut',
+                      #path='WGToLNuG_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
+                      path='WGToLNuG_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhCutMax',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kOrange, XSName='WGToLNuG-madgraphMLM' )
+
+    samples.AddSample('WGToLNuG_PtG-130-madgraphMLMMTResCut',
+                      #path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
+                      path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhCutMaxPhCutMin',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kViolet, XSName='WGToLNuG_PtG-130-madgraphMLM' )
+
+    samples.AddSample('WGToLNuG_PtG-500-madgraphMLMMTResCut',
+                      path='WGToLNuG_PtG-500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
+                      isActive=False, useXSFile=True, plotColor=ROOT.kCyan , XSName='WGToLNuG_PtG-500-madgraphMLM'  )
+
+
+    samples.AddSample('WJetsToLNu-madgraphMLM',
+                      path='WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('WJetsToLNu-madgraphMLMPhOlap',
+                      path='WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('WJetsToLNu-amcatnloFXFX',
+                      path='WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhOlap',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('WWG',
+                      path='WWG_TuneCUETP8M1_13TeV-amcatnlo-pythia8',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('tW_top',
+                      path='ST_tW_top_5f_NoFullyHadronicDecays_13TeV-powheg_TuneCUETP8M1',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('tW_antitop',
+                      path='ST_tW_antitop_5f_NoFullyHadronicDecays_13TeV-powheg_TuneCUETP8M1',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('DiPhoton',
+                      path='DiPhotonJets_MGG-80toInf_13TeV_amcatnloFXFX_pythia8',
+                      isActive=False, useXSFile=True )
+
+    samples.AddSample('WJetsToLNuTrueHTOlap',
+                      path='WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8TrueHTOlapPhOlap',
+                      isActive=False, plotColor=ROOT.kGreen-5, useXSFile=True, XSName='WJetsToLNu-madgraphMLM')
+
+    samples.AddSample('WJetsToLNu_HT-100To200',
+                      path='WJetsToLNu_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      isActive=False, plotColor=ROOT.kGreen , useXSFile=True )
+
+    samples.AddSample('WJetsToLNu_HT-200To400',
+                      path='WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      isActive=False, plotColor=ROOT.kCyan  , useXSFile=True )
+
+    samples.AddSample('WJetsToLNu_HT-400To600',
+                      path='WJetsToLNu_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      isActive=False, plotColor=ROOT.kViolet, useXSFile=True )
+
+    samples.AddSample('WJetsToLNu_HT-600To800',
+                      path='WJetsToLNu_HT-600To800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      isActive=False, plotColor=ROOT.kOrange, useXSFile=True )
+
+    samples.AddSample('WJetsToLNu_HT-800To1200',
+                      path='WJetsToLNu_HT-800To1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      isActive=False, plotColor=ROOT.kSpring, useXSFile=True )
+
+    samples.AddSample('WJetsToLNu_HT-1200To2500',
+                      path='WJetsToLNu_HT-1200To2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      isActive=False, plotColor=ROOT.kGray  , useXSFile=True )
+
+    samples.AddSample('WJetsToLNu_HT-2500ToInf',
+                      path='WJetsToLNu_HT-2500ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
+                      isActive=False, plotColor=ROOT.kRed+6  , useXSFile=True )
+
+    samples.AddSample('WJetsToLNu_Pt-0To50',
+                      path='WJetsToLNu_Wpt-0To50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, plotColor=ROOT.kGreen-5, useXSFile=True )
+    samples.AddSample('WJetsToLNu_Pt-50To100',
+                      path='WJetsToLNu_Wpt-50To100_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, plotColor=ROOT.kGreen, useXSFile=True )
+    samples.AddSample('WJetsToLNu_Pt-100To250',
+                      path='WJetsToLNu_Pt-100To250_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, plotColor=ROOT.kCyan, useXSFile=True )
+    samples.AddSample('WJetsToLNu_Pt-250To400',
+                      path='WJetsToLNu_Pt-250To400_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, plotColor=ROOT.kViolet, useXSFile=True )
+    samples.AddSample('WJetsToLNu_Pt-400To600',
+                      path='WJetsToLNu_Pt-400To600_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, plotColor=ROOT.kOrange, useXSFile=True )
+    samples.AddSample('WJetsToLNu_Pt-600ToInf',
+                      path='WJetsToLNu_Pt-600ToInf_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, plotColor=ROOT.kSpring, useXSFile=True )
+    samples.AddSample('WToLNu_0J',
+                      path='WToLNu_0J_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, plotColor=ROOT.kGray, useXSFile=True )
+    samples.AddSample('WToLNu_1J',
+                      path='WToLNu_1J_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, plotColor=ROOT.kRed+2, useXSFile=True )
+    samples.AddSample('WToLNu_2J',
+                      path='WToLNu_2J_13TeV-amcatnloFXFX-pythia8',
+                      isActive=False, plotColor=ROOT.kPink, useXSFile=True )
+
+    samples.AddSample('GJets_HT-40To100' , path='GJets_HT-40To100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8', isActive=False, useXSFile=True)
+    samples.AddSample('GJets_HT-100To200', path='GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8', isActive=False, useXSFile=True)
+    samples.AddSample('GJets_HT-200To400', path='GJets_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8', isActive=False, useXSFile=True)
+    samples.AddSample('GJets_HT-400To600', path='GJets_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8', isActive=False, useXSFile=True)
+    samples.AddSample('GJets_HT-600ToInf', path='GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8', isActive=False, useXSFile=True)
+
+    samples.AddSample('MadGraphResonanceMass200_width0p01', path='MadGraphChargedResonance_WGToLNu_M200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kCyan, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 200 GeV', XSName='ResonanceMass200')
+    samples.AddSample('MadGraphResonanceMass200_width5', path='MadGraphChargedResonance_WGToLNu_M200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 200 GeV', XSName='ResonanceMass200')
+    samples.AddSample('MadGraphResonanceMass250_width0p01', path='MadGraphChargedResonance_WGToLNu_M250_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kPink-1, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250') ## TODO ACTIVE SIGNAL
+    samples.AddSample('MadGraphResonanceMass250_width5', path='MadGraphChargedResonance_WGToLNu_M250_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250')
+    samples.AddSample('MadGraphResonanceMass300_width0p01', path='MadGraphChargedResonance_WGToLNu_M300_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = 'M(#Phi^{#pm}) = 300 GeV', XSName='ResonanceMass300') #
+    samples.AddSample('MadGraphResonanceMass300_width5', path='MadGraphChargedResonance_WGToLNu_M300_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 300 GeV', XSName='ResonanceMass300')
+    samples.AddSample('MadGraphResonanceMass350_width0p01', path='MadGraphChargedResonance_WGToLNu_M350_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 350 GeV', XSName='ResonanceMass350')
+    samples.AddSample('MadGraphResonanceMass350_width5', path='MadGraphChargedResonance_WGToLNu_M350_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 350 GeV', XSName='ResonanceMass350')
+    samples.AddSample('MadGraphResonanceMass400_width0p01', path='MadGraphChargedResonance_WGToLNu_M400_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kBlack, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 400 GeV', XSName='ResonanceMass400')
+    samples.AddSample('MadGraphResonanceMass400_width5', path='MadGraphChargedResonance_WGToLNu_M400_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 400 GeV', XSName='ResonanceMass400')
+    samples.AddSample('MadGraphResonanceMass450_width0p01', path='MadGraphChargedResonance_WGToLNu_M450_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 450 GeV', XSName='ResonanceMass450')
+    samples.AddSample('MadGraphResonanceMass450_width5', path='MadGraphChargedResonance_WGToLNu_M450_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kBlue, legend_name = 'M(#Phi^{#pm}) = 450 GeV', XSName='ResonanceMass450') #
+    samples.AddSample('MadGraphResonanceMass500_width0p01', path='MadGraphChargedResonance_WGToLNu_M500_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 500 GeV', XSName='ResonanceMass500')
+    samples.AddSample('MadGraphResonanceMass500_width5', path='MadGraphChargedResonance_WGToLNu_M500_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 500 GeV', XSName='ResonanceMass500')
+    samples.AddSample('MadGraphResonanceMass600_width0p01', path='MadGraphChargedResonance_WGToLNu_M600_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 600 GeV', XSName='ResonanceMass600')
+    samples.AddSample('MadGraphResonanceMass600_width5', path='MadGraphChargedResonance_WGToLNu_M600_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 600 GeV', XSName='ResonanceMass600')
+    samples.AddSample('MadGraphResonanceMass700_width0p01', path='MadGraphChargedResonance_WGToLNu_M700_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 700 GeV', XSName='ResonanceMass700')
+    samples.AddSample('MadGraphResonanceMass700_width5', path='MadGraphChargedResonance_WGToLNu_M700_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 700 GeV', XSName='ResonanceMass700')
+    samples.AddSample('MadGraphResonanceMass800_width0p01', path='MadGraphChargedResonance_WGToLNu_M800_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kMagenta, legend_name = 'M(#Phi^{#pm}) = 800 GeV', XSName='ResonanceMass800') #
+    samples.AddSample('MadGraphResonanceMass800_width5', path='MadGraphChargedResonance_WGToLNu_M800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 800 GeV', XSName='ResonanceMass800')
+    samples.AddSample('MadGraphResonanceMass900_width0p01', path='MadGraphChargedResonance_WGToLNu_M900_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 900 GeV', XSName='ResonanceMass900')
+    samples.AddSample('MadGraphResonanceMass900_width5', path='MadGraphChargedResonance_WGToLNu_M900_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 900 GeV', XSName='ResonanceMass900')
+    samples.AddSample('MadGraphResonanceMass1000_width0p01', path='MadGraphChargedResonance_WGToLNu_M1000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kPink+10, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000') ##TODO ACTIVE SIGNAL
+    samples.AddSample('MadGraphResonanceMass1000_width5', path='MadGraphChargedResonance_WGToLNu_M1000_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000')
+    samples.AddSample('MadGraphResonanceMass1200_width0p01', path='MadGraphChargedResonance_WGToLNu_M1200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1200 GeV', XSName='ResonanceMass1200')
+    samples.AddSample('MadGraphResonanceMass1200_width5', path='MadGraphChargedResonance_WGToLNu_M1200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1200 GeV', XSName='ResonanceMass1200')
+    samples.AddSample('MadGraphResonanceMass1400_width0p01', path='MadGraphChargedResonance_WGToLNu_M1400_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1400 GeV', XSName='ResonanceMass1400')
+    samples.AddSample('MadGraphResonanceMass1400_width5', path='MadGraphChargedResonance_WGToLNu_M1400_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1400 GeV', XSName='ResonanceMass1400')
+    samples.AddSample('MadGraphResonanceMass1600_width0p01', path='MadGraphChargedResonance_WGToLNu_M1600_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1600 GeV', XSName='ResonanceMass1600')
+    samples.AddSample('MadGraphResonanceMass1600_width5', path='MadGraphChargedResonance_WGToLNu_M1600_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1600 GeV', XSName='ResonanceMass1600') ## TODO ACTIVE SIGNAL
+    samples.AddSample('MadGraphResonanceMass1800_width0p01', path='MadGraphChargedResonance_WGToLNu_M1800_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1800 GeV', XSName='ResonanceMass1800')
+    samples.AddSample('MadGraphResonanceMass1800_width5', path='MadGraphChargedResonance_WGToLNu_M1800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1800 GeV', XSName='ResonanceMass1800')
+    samples.AddSample('MadGraphResonanceMass2000_width0p01', path='MadGraphChargedResonance_WGToLNu_M2000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kGreen, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2000 GeV', XSName='ResonanceMass2000')
+    samples.AddSample('MadGraphResonanceMass2000_width5', path='MadGraphChargedResonance_WGToLNu_M2000_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2000 GeV', XSName='ResonanceMass2000')
+    samples.AddSample('MadGraphResonanceMass2200_width0p01', path='MadGraphChargedResonance_WGToLNu_M2200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2200 GeV', XSName='ResonanceMass2200')
+    samples.AddSample('MadGraphResonanceMass2200_width5', path='MadGraphChargedResonance_WGToLNu_M2200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2200 GeV', XSName='ResonanceMass2200')
+    samples.AddSample('MadGraphResonanceMass2400_width0p01', path='MadGraphChargedResonance_WGToLNu_M2400_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2400 GeV', XSName='ResonanceMass2400')
+    samples.AddSample('MadGraphResonanceMass2400_width5', path='MadGraphChargedResonance_WGToLNu_M2400_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2400 GeV', XSName='ResonanceMass2400')
+    samples.AddSample('MadGraphResonanceMass2600_width0p01', path='MadGraphChargedResonance_WGToLNu_M2600_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2600 GeV', XSName='ResonanceMass2600')
+    samples.AddSample('MadGraphResonanceMass2800_width0p01', path='MadGraphChargedResonance_WGToLNu_M2800_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2800 GeV', XSName='ResonanceMass2800')
+    samples.AddSample('MadGraphResonanceMass2800_width5', path='MadGraphChargedResonance_WGToLNu_M2800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2800 GeV', XSName='ResonanceMass2800')
+    samples.AddSample('MadGraphResonanceMass3000_width0p01', path='MadGraphChargedResonance_WGToLNu_M3000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 3000 GeV', XSName='ResonanceMass3000')
+    samples.AddSample('MadGraphResonanceMass3500_width0p01', path='MadGraphChargedResonance_WGToLNu_M3500_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 3500 GeV', XSName='ResonanceMass3500')
+    samples.AddSample('MadGraphResonanceMass3500_width5', path='MadGraphChargedResonance_WGToLNu_M3500_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 3500 GeV', XSName='ResonanceMass3500')
+    samples.AddSample('MadGraphResonanceMass4000_width0p01', path='MadGraphChargedResonance_WGToLNu_M4000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 4000 GeV', XSName='ResonanceMass4000')
+    samples.AddSample('MadGraphResonanceMass4000_width5', path='MadGraphChargedResonance_WGToLNu_M4000_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 4000 GeV', XSName='ResonanceMass4000')
+
+    samples.AddSample('PythiaResonanceMass200_width0p01', path='PythiaChargedResonance_WGToLNu_M200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kCyan, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 200 GeV', XSName='ResonanceMass200')
+    samples.AddSample('PythiaResonanceMass200_width5', path='PythiaChargedResonance_WGToLNu_M200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 200 GeV', XSName='ResonanceMass200')
+    samples.AddSample('PythiaResonanceMass250_width0p01', path='PythiaChargedResonance_WGToLNu_M250_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250')
+    samples.AddSample('PythiaResonanceMass250_width5', path='PythiaChargedResonance_WGToLNu_M250_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250')
+    samples.AddSample('PythiaResonanceMass300_width0p01', path='PythiaChargedResonance_WGToLNu_M300_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 300 GeV', XSName='ResonanceMass300')
+    samples.AddSample('PythiaResonanceMass300_width5', path='PythiaChargedResonance_WGToLNu_M300_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 300 GeV', XSName='ResonanceMass300')
+    samples.AddSample('PythiaResonanceMass350_width0p01', path='PythiaChargedResonance_WGToLNu_M350_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 350 GeV', XSName='ResonanceMass350')
+    samples.AddSample('PythiaResonanceMass350_width5', path='PythiaChargedResonance_WGToLNu_M350_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 350 GeV', XSName='ResonanceMass350')
+    samples.AddSample('PythiaResonanceMass400_width0p01', path='PythiaChargedResonance_WGToLNu_M400_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kBlack, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 400 GeV', XSName='ResonanceMass400')
+    samples.AddSample('PythiaResonanceMass400_width5', path='PythiaChargedResonance_WGToLNu_M400_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 400 GeV', XSName='ResonanceMass400')
+    samples.AddSample('PythiaResonanceMass450_width0p01', path='PythiaChargedResonance_WGToLNu_M450_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 450 GeV', XSName='ResonanceMass450')
+    samples.AddSample('PythiaResonanceMass450_width5', path='PythiaChargedResonance_WGToLNu_M450_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 450 GeV', XSName='ResonanceMass450')
+    samples.AddSample('PythiaResonanceMass500_width0p01', path='PythiaChargedResonance_WGToLNu_M500_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 500 GeV', XSName='ResonanceMass500')
+    samples.AddSample('PythiaResonanceMass500_width5', path='PythiaChargedResonance_WGToLNu_M500_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 500 GeV', XSName='ResonanceMass500')
+    samples.AddSample('PythiaResonanceMass600_width0p01', path='PythiaChargedResonance_WGToLNu_M600_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 600 GeV', XSName='ResonanceMass600')
+    samples.AddSample('PythiaResonanceMass600_width5', path='PythiaChargedResonance_WGToLNu_M600_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 600 GeV', XSName='ResonanceMass600')
+    samples.AddSample('PythiaResonanceMass700_width0p01', path='PythiaChargedResonance_WGToLNu_M700_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 700 GeV', XSName='ResonanceMass700')
+    samples.AddSample('PythiaResonanceMass700_width5', path='PythiaChargedResonance_WGToLNu_M700_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 700 GeV', XSName='ResonanceMass700')
+    samples.AddSample('PythiaResonanceMass800_width0p01', path='PythiaChargedResonance_WGToLNu_M800_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kMagenta, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 800 GeV', XSName='ResonanceMass800')
+    samples.AddSample('PythiaResonanceMass800_width5', path='PythiaChargedResonance_WGToLNu_M800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 800 GeV', XSName='ResonanceMass800')
+    samples.AddSample('PythiaResonanceMass900_width0p01', path='PythiaChargedResonance_WGToLNu_M900_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 900 GeV', XSName='ResonanceMass900')
+    samples.AddSample('PythiaResonanceMass900_width5', path='PythiaChargedResonance_WGToLNu_M900_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 900 GeV', XSName='ResonanceMass900')
+    samples.AddSample('PythiaResonanceMass1000_width0p01', path='PythiaChargedResonance_WGToLNu_M1000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000')
+    samples.AddSample('PythiaResonanceMass1000_width5', path='PythiaChargedResonance_WGToLNu_M1000_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000')
+    samples.AddSample('PythiaResonanceMass1200_width0p01', path='PythiaChargedResonance_WGToLNu_M1200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1200 GeV', XSName='ResonanceMass1200')
+    samples.AddSample('PythiaResonanceMass1200_width5', path='PythiaChargedResonance_WGToLNu_M1200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1200 GeV', XSName='ResonanceMass1200')
+    samples.AddSample('PythiaResonanceMass1400_width0p01', path='PythiaChargedResonance_WGToLNu_M1400_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1400 GeV', XSName='ResonanceMass1400')
+    samples.AddSample('PythiaResonanceMass1400_width5', path='PythiaChargedResonance_WGToLNu_M1400_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1400 GeV', XSName='ResonanceMass1400')
+    samples.AddSample('PythiaResonanceMass1600_width0p01', path='PythiaChargedResonance_WGToLNu_M1600_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1600 GeV', XSName='ResonanceMass1600')
+    samples.AddSample('PythiaResonanceMass1600_width5', path='PythiaChargedResonance_WGToLNu_M1600_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1600 GeV', XSName='ResonanceMass1600')
+    samples.AddSample('PythiaResonanceMass1800_width0p01', path='PythiaChargedResonance_WGToLNu_M1800_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1800 GeV', XSName='ResonanceMass1800')
+    samples.AddSample('PythiaResonanceMass1800_width5', path='PythiaChargedResonance_WGToLNu_M1800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1800 GeV', XSName='ResonanceMass1800')
+    samples.AddSample('PythiaResonanceMass2000_width0p01', path='PythiaChargedResonance_WGToLNu_M2000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kGreen, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2000 GeV', XSName='ResonanceMass2000')
+    samples.AddSample('PythiaResonanceMass2000_width5', path='PythiaChargedResonance_WGToLNu_M2000_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2000 GeV', XSName='ResonanceMass2000')
+    samples.AddSample('PythiaResonanceMass2200_width0p01', path='PythiaChargedResonance_WGToLNu_M2200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2200 GeV', XSName='ResonanceMass2200')
+    samples.AddSample('PythiaResonanceMass2200_width5', path='PythiaChargedResonance_WGToLNu_M2200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2200 GeV', XSName='ResonanceMass2200')
+    samples.AddSample('PythiaResonanceMass2400_width0p01', path='PythiaChargedResonance_WGToLNu_M2400_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2400 GeVV', XSName='ResonanceMass2400')
+    samples.AddSample('PythiaResonanceMass2400_width5', path='PythiaChargedResonance_WGToLNu_M2400_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2400 GeV', XSName='ResonanceMass2400')
+    samples.AddSample('PythiaResonanceMass2600_width0p01', path='PythiaChargedResonance_WGToLNu_M2600_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2600 GeV', XSName='ResonanceMass2600')
+    samples.AddSample('PythiaResonanceMass2800_width0p01', path='PythiaChargedResonance_WGToLNu_M2800_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2800 GeV', XSName='ResonanceMass2800')
+    samples.AddSample('PythiaResonanceMass2800_width5', path='PythiaChargedResonance_WGToLNu_M2800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2800 GeV', XSName='ResonanceMass2800')
+    samples.AddSample('PythiaResonanceMass3000_width0p01', path='PythiaChargedResonance_WGToLNu_M3000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 3000 GeV', XSName='ResonanceMass3000')
+    samples.AddSample('PythiaResonanceMass3500_width0p01', path='PythiaChargedResonance_WGToLNu_M3500_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 3500 GeV', XSName='ResonanceMass3500')
+    samples.AddSample('PythiaResonanceMass3500_width5', path='PythiaChargedResonance_WGToLNu_M3500_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 3500 GeV', XSName='ResonanceMass3500')
+    samples.AddSample('PythiaResonanceMass4000_width0p01', path='PythiaChargedResonance_WGToLNu_M4000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 4000 GeV', XSName='ResonanceMass4000')
+    samples.AddSample('PythiaResonanceMass4000_width5', path='PythiaChargedResonance_WGToLNu_M4000_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 4000 GeV', XSName='ResonanceMass4000')
+
+
+    samples.AddSampleGroup( 'Data', legend_name='Data',
+                            input_samples = [
+                                             'SingleMuon',
+                                             'SingleElectron',
+                                            ],
+                           plotColor=ROOT.kBlack,
+                           isData=True,
+                          )
+
+
+    samples.AddSampleGroup(  'WGamma', legend_name='W#gamma',
+                           input_samples = ['WGToLNuG-amcatnloFXFXPhCut', 'WGToLNuG_PtG-130-amcatnloFXFXPhCut','WGToLNuG_PtG-500-amcatnloFXFXPhCut'],
+                           #input_samples = ['WGToLNuG-amcatnloFXFX'],
+                           plotColor = ROOT.kRed-2,
+                           isActive = False
+                          )
+
+    samples.AddSampleGroup( 'GammaGamma', legend_name='#gamma#gamma',
+                           input_samples = [
+                                           'DiPhoton',
+                           ],
+                           plotColor = ROOT.kYellow,
+                           isActive = False
+                          )
+
+    samples.AddSampleGroup(  'Zgamma', legend_name='Z#gamma',
+                           input_samples = ['ZGTo2LG'],
+                           plotColor = ROOT.kRed-8,
+                           isActive=False
+                          )
+
+    samples.AddSampleGroup(  'Z+jetsLO', legend_name='Z+JetsLO',
+                           input_samples = ['DYJetsToLL_M-50'],
+                           plotColor = ROOT.kCyan-2,
+                           isActive=False,
+                          )
+
+    samples.AddSampleGroup(  'Z+jets', legend_name='Z+Jets',
+                           input_samples = ['DYJetsToLL_M-50-amcatnloFXFXPhOlap'],
+                           #input_samples = ['DYJetsToLL_M-50-amcatnloFXFX'],
+                           plotColor = ROOT.kCyan-5,
+                          )
+
+
+
+
+    samples.AddSampleGroup(  'WgammaLO', legend_name='W#gamma LO',
+#                           #input_samples = ['WGToLNuG-madgraphMLMPhCut', 'WGToLNuG_PtG-130-madgraphMLMPhCut','WGToLNuG_PtG-500-madgraphMLMPhCut' ],
+                           input_samples = ['WGToLNuG-madgraphMLMMTResCut', 'WGToLNuG_PtG-130-madgraphMLMMTResCut','WGToLNuG_PtG-500-madgraphMLMMTResCut' ],
+#                           #input_samples = ['WGToLNuG_PtG-130-madgraphMLMPhCut','WGToLNuG_PtG-500-madgraphMLMPhCut' ],
+                           plotColor = ROOT.kRed-2,
+                           isActive=False,
+                          )
+
+    samples.AddSampleGroup(  'Wjets', legend_name='W+Jets',
+                           #input_samples = ['WJetsToLNu-madgraphMLM'],
+                           #input_samples = ['WJetsToLNu-amcatnloFXFX'],
+                           input_samples = [
+                                            #'WJetsToLNuTrueHTOlap',
+                                            'WJetsToLNu_HT-100To200',
+                                            'WJetsToLNu_HT-200To400',
+                                            'WJetsToLNu_HT-400To600',
+                                            'WJetsToLNu_HT-600To800',
+                                            'WJetsToLNu_HT-800To1200',
+                                            'WJetsToLNu_HT-1200To2500',
+                                            'WJetsToLNu_HT-2500ToInf',
+                           ],
+                           plotColor = ROOT.kBlue-2,
+                           isActive=False,
+                          )
+##>>
+    samples.AddSampleGroup( 'TTG', legend_name='t#bar{t}#gamma',
+                           input_samples = ['TTGJets'],
+                           plotColor = ROOT.kAzure+1,
+                           isActive=False,
+                          )
+
+    samples.AddSampleGroup( 'WjetsSMPIncl', legend_name='W+Jets',
+                            input_samples = ['WJetsToLNu-amcatnloFXFX'],
+                            plotColor = ROOT.kBlue-2,
+                            isActive=False
+                            )
+
+    samples.AddSampleGroup( 'WjetsSMPPt', legend_name='W+Jets',
+                            input_samples = [
+                            'WJetsToLNu_Pt-0To50',
+                            'WJetsToLNu_Pt-50To100',
+                            'WJetsToLNu_Pt-100To250',
+                            'WJetsToLNu_Pt-250To400',
+                            'WJetsToLNu_Pt-400To600',
+                            'WJetsToLNu_Pt-600ToInf',
+                            ],
+                            plotColor = ROOT.kBlue-2,
+                            )
+
+    samples.AddSampleGroup( 'WjetsSMPJet', legend_name='W+Jets',
+                            input_samples = [
+                            'WToLNu_0J',
+                            'WToLNu_1J',
+                            'WToLNu_2J',
+                            ],
+                            plotColor = ROOT.kBlue-2,
+                            )
+
+
+    samples.AddSampleGroup( 'GJets', legend_name='#gamma + jets',
+                           input_samples = [
+                                           'GJets_HT-100To200',
+                                           'GJets_HT-200To400',
+                                           'GJets_HT-400To600',
+                                           'GJets_HT-40To100' ,
+                                           'GJets_HT-600ToInf',
+                           ],
+                           plotColor = ROOT.kOrange,
+                           isActive=False,
+                          )
+
+
+
+
+    samples.AddSampleGroup( 'TTbar_DiLep', legend_name='t#bar{t} dileptonic',
+                           input_samples = ['TTJets_DiLept'],
+                           plotColor = ROOT.kMagenta+2,
+                           isActive=False,
+                          )
+
+    samples.AddSampleGroup( 'TTbar_SingleLep', legend_name='t#bar{t} semileptonic',
+                           input_samples = ['TTJets_SingleLeptFromTbar', 'TTJets_SingleLeptFromT'],
+                           plotColor = ROOT.kGreen+2,
+                           isActive=False,
+                          )
+
+    samples.AddSampleGroup( 'AllTop', legend_name='t#bar{t}',
+                           input_samples = ['TTbar_DiLep', 'TTbar_SingleLep'],
+                           plotColor = ROOT.kGreen+3,
+                           isActive=False,
+                          )
+
+    samples.AddSampleGroup( 'TopW', legend_name='tW',
+                           input_samples = ['tW_top','tW_antitop'],
+                           plotColor = ROOT.kOrange+3,
+                           isActive=False,
+                          )
+
+    samples.AddSampleGroup( 'Others', legend_name='Others',
+                           input_samples = ['TTbar_DiLep', 'TTbar_SingleLep','TTG','GJets','Wjets'],
+                           plotColor = ROOT.kGray,
+                           isActive=False,
+                          )
+
+    samples.AddSampleGroup( 'MCBackground', legend_name='MC Background',
+                           input_samples = ['WGamma', 'Wjets', 'TTbar_DiLep', 'TTbar_SingleLep'],
+                           isActive=False,
+                          )
+    samples.AddSampleGroup( 'MCBackgroundLO', legend_name='MC Background',
+                           input_samples = ['WgammaLO', 'Wjets', 'TTbar_DiLep', 'TTbar_SingleLep'],
+                           isActive=False,
+                          )
+    samples.AddSampleGroup( 'JetBackground', legend_name='Jet Background',
+                           input_samples = ['Wjets', 'TTbar_SingleLep'],
+                           isActive=False,
+                          )
+
+    samples.AddSampleGroup( 'EleFakeBackground',
+                           input_samples = ['Z+jets', 'Zgamma', 'TTbar_DiLep', 'TopW'],
+                           isActive=False,
+                          )
+
+    samples.AddSampleGroup( 'OtherEleFakeBackground', legend_name='Other Electron Fakes',
+                           input_samples = [ 'TTbar_DiLep', 'TopW'],
+                           plotColor=ROOT.kRed-7,
+                           #isActive=False,
+                          )
+
+    samples.AddSampleGroup( 'NonEleFake', legend_name='Non-electron Fakes',
+                           input_samples = ['WGamma','Wjets', 'TTbar_SingleLep','TTG','DiPhoton','GJets',"Zgamma"],
+                           plotColor=ROOT.kOrange+1,
+                          )
+
+def print_examples() :
+    pass
+

--- a/Plotting/Modules/Resonance2016_efake.py
+++ b/Plotting/Modules/Resonance2016_efake.py
@@ -65,13 +65,11 @@ def config_samples(samples) :
                       isActive=False, useXSFile=True, plotColor=ROOT.kCyan   )
 
     samples.AddSample('WGToLNuG-amcatnloFXFXPhCut',
-                      path='WGToLNuG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutRange',
-                      #path='WGToLNuG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutMax',
+                      path='WGToLNuG_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutMax',
                       isActive=False, useXSFile=True, plotColor=ROOT.kOrange, XSName='WGToLNuG-amcatnloFXFX')
 
     samples.AddSample('WGToLNuG_PtG-130-amcatnloFXFXPhCut',
-                      path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutMaxPhCutMin',
-                      #path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutMaxPhCutMin',
+                      path='WGToLNuG_PtG-130_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8PhCutRange',
                       isActive=False, useXSFile=True, plotColor=ROOT.kViolet, XSName='WGToLNuG_PtG-130-amcatnloFXFX' )
 
     samples.AddSample('WGToLNuG_PtG-500-amcatnloFXFXPhCut',

--- a/Plotting/Modules/Resonance2017.py
+++ b/Plotting/Modules/Resonance2017.py
@@ -23,16 +23,18 @@ def config_samples(samples) :
                       isActive=False, useXSFile=True )
 
     samples.AddSample('TTJets_DiLept',
-                      path='TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8PhOlap',
-                      #path='TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8',
+                      #path='TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8PhOlap',
+                      path='TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8',
                       isActive=False, useXSFile=True )
 
     samples.AddSample('TTJets_SingleLeptFromTbar',
-                      path='TTJets_SingleLeptFromTbar_TuneCP5_13TeV-madgraphMLM-pythia8PhOlap',
+                      #path='TTJets_SingleLeptFromTbar_TuneCP5_13TeV-madgraphMLM-pythia8PhOlap',
+                      path='TTJets_SingleLeptFromTbar_TuneCP5_13TeV-madgraphMLM-pythia8',
                       isActive=False, useXSFile=True )
 
     samples.AddSample('TTJets_SingleLeptFromT',
-                      path='TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8PhOlap',
+                      #path='TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8PhOlap',
+                      path='TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8',
                       isActive=False, useXSFile=True )
 
     samples.AddSample('TTGJets',
@@ -69,7 +71,7 @@ def config_samples(samples) :
                       isActive=False, useXSFile=True, plotColor=ROOT.kOrange, XSName='WGToLNuG-amcatnloFXFX')
 
     samples.AddSample('WGToLNuG_PtG-130-amcatnloFXFXPhCut',
-                      path='WGToLNuG_PtG-130_TuneCP5_13TeV-amcatnloFXFX-pythia8PhCutMaxPhCutMin',
+                      path='WGToLNuG_PtG-130_TuneCP5_13TeV-amcatnloFXFX-pythia8PhCutRange',
                       #path='WGToLNuG_PtG-130_TuneCP5_13TeV-amcatnloFXFX-pythia8PhCutMaxPhCutMin',
                       isActive=False, useXSFile=True, plotColor=ROOT.kViolet, XSName='WGToLNuG_PtG-130-amcatnloFXFX' )
 
@@ -203,7 +205,7 @@ def config_samples(samples) :
     samples.AddSample('MadGraphResonanceMass200_width0p01', path='MadGraphChargedResonance_WGToLNuG_M200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kCyan, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 200 GeV', XSName='ResonanceMass200')
     samples.AddSample('MadGraphResonanceMass200_width5', path='MadGraphChargedResonance_WGToLNuG_M200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 200 GeV', XSName='ResonanceMass200')
     samples.AddSample('MadGraphResonanceMass250_width0p01', path='MadGraphChargedResonance_WGToLNuG_M250_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250')
-    samples.AddSample('MadGraphResonanceMass250_width5', path='MadGraphChargedResonance_WGToLNuG_M250_width5', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250')
+    samples.AddSample('MadGraphResonanceMass250_width5', path='MadGraphChargedResonance_WGToLNuG_M250_width5', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kPink-1, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250') #TODO: Active signal
     samples.AddSample('MadGraphResonanceMass300_width0p01', path='MadGraphChargedResonance_WGToLNuG_M300_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = 'M(#Phi^{#pm}) = 300 GeV', XSName='ResonanceMass300') #
     samples.AddSample('MadGraphResonanceMass300_width5', path='MadGraphChargedResonance_WGToLNuG_M300_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 300 GeV', XSName='ResonanceMass300')
     samples.AddSample('MadGraphResonanceMass350_width0p01', path='MadGraphChargedResonance_WGToLNuG_M350_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 350 GeV', XSName='ResonanceMass350')
@@ -222,7 +224,7 @@ def config_samples(samples) :
     samples.AddSample('MadGraphResonanceMass800_width5', path='MadGraphChargedResonance_WGToLNuG_M800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 800 GeV', XSName='ResonanceMass800')
     samples.AddSample('MadGraphResonanceMass900_width0p01', path='MadGraphChargedResonance_WGToLNuG_M900_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 900 GeV', XSName='ResonanceMass900')
     samples.AddSample('MadGraphResonanceMass900_width5', path='MadGraphChargedResonance_WGToLNuG_M900_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 900 GeV', XSName='ResonanceMass900')
-    samples.AddSample('MadGraphResonanceMass1000_width0p01', path='MadGraphChargedResonance_WGToLNuG_M1000_width0p01', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000')
+    samples.AddSample('MadGraphResonanceMass1000_width0p01', path='MadGraphChargedResonance_WGToLNuG_M1000_width0p01', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kPink+10, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000') #TODO: Active signal
     samples.AddSample('MadGraphResonanceMass1000_width5', path='MadGraphChargedResonance_WGToLNuG_M1000_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000')
     samples.AddSample('MadGraphResonanceMass1200_width0p01', path='MadGraphChargedResonance_WGToLNuG_M1200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1200 GeV', XSName='ResonanceMass1200')
     samples.AddSample('MadGraphResonanceMass1200_width5', path='MadGraphChargedResonance_WGToLNuG_M1200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1200 GeV', XSName='ResonanceMass1200')
@@ -234,7 +236,7 @@ def config_samples(samples) :
     samples.AddSample('MadGraphResonanceMass1800_width5', path='MadGraphChargedResonance_WGToLNuG_M1800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1800 GeV', XSName='ResonanceMass1800')
     samples.AddSample('MadGraphResonanceMass2000_width0p01', path='MadGraphChargedResonance_WGToLNuG_M2000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kGreen, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2000 GeV', XSName='ResonanceMass2000')
     samples.AddSample('MadGraphResonanceMass2000_width5', path='MadGraphChargedResonance_WGToLNuG_M2000_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2000 GeV', XSName='ResonanceMass2000')
-    samples.AddSample('MadGraphResonanceMass2200_width0p01', path='MadGraphChargedResonance_WGToLNuG_M2200_width0p01', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2200 GeV', XSName='ResonanceMass2200')
+    samples.AddSample('MadGraphResonanceMass2200_width0p01', path='MadGraphChargedResonance_WGToLNuG_M2200_width0p01', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2200 GeV', XSName='ResonanceMass2200')#TODO: Active signal
     samples.AddSample('MadGraphResonanceMass2200_width5', path='MadGraphChargedResonance_WGToLNuG_M2200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2200 GeV', XSName='ResonanceMass2200')
     samples.AddSample('MadGraphResonanceMass2400_width0p01', path='MadGraphChargedResonance_WGToLNuG_M2400_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2400 GeV', XSName='ResonanceMass2400')
     samples.AddSample('MadGraphResonanceMass2400_width5', path='MadGraphChargedResonance_WGToLNuG_M2400_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2400 GeV', XSName='ResonanceMass2400')

--- a/Plotting/Modules/Resonance2018.py
+++ b/Plotting/Modules/Resonance2018.py
@@ -24,8 +24,8 @@ def config_samples(samples) :
                       isActive=False, useXSFile=True )
 
     samples.AddSample('TTJets_DiLept',
-                      path='TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8PhOlap',
-                      #path='TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8',
+                      #path='TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8PhOlap',
+                      path='TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8',
                       isActive=False, useXSFile=True )
 
     samples.AddSample('TTJets_SingleLeptFromTbar',
@@ -70,7 +70,7 @@ def config_samples(samples) :
                       isActive=False, useXSFile=True, plotColor=ROOT.kOrange, XSName='WGToLNuG-amcatnloFXFX')
 
     samples.AddSample('WGToLNuG_PtG-130-amcatnloFXFXPhCut',
-                      path='WGToLNuG_PtG-130_TuneCP5_13TeV-amcatnloFXFX-pythia8PhCutMaxPhCutMin',
+                      path='WGToLNuG_PtG-130_TuneCP5_13TeV-amcatnloFXFX-pythia8PhCutRange',
                       #path='WGToLNuG_PtG-130_TuneCP5_13TeV-amcatnloFXFX-pythia8PhCutMaxPhCutMin',
                       isActive=False, useXSFile=True, plotColor=ROOT.kViolet, XSName='WGToLNuG_PtG-130-amcatnloFXFX' )
 
@@ -204,7 +204,7 @@ def config_samples(samples) :
     samples.AddSample('MadGraphResonanceMass200_width0p01', path='MadGraphChargedResonance_WGToLNuG_M200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kCyan, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 200 GeV', XSName='ResonanceMass200')
     samples.AddSample('MadGraphResonanceMass200_width5', path='MadGraphChargedResonance_WGToLNuG_M200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 200 GeV', XSName='ResonanceMass200')
     samples.AddSample('MadGraphResonanceMass250_width0p01', path='MadGraphChargedResonance_WGToLNuG_M250_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250')
-    samples.AddSample('MadGraphResonanceMass250_width5', path='MadGraphChargedResonance_WGToLNuG_M250_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250')
+    samples.AddSample('MadGraphResonanceMass250_width5', path='MadGraphChargedResonance_WGToLNuG_M250_width5', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kPink-1, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 250 GeV', XSName='ResonanceMass250')  #TODO:Active Signal
     samples.AddSample('MadGraphResonanceMass300_width0p01', path='MadGraphChargedResonance_WGToLNuG_M300_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = 'M(#Phi^{#pm}) = 300 GeV', XSName='ResonanceMass300') #
     samples.AddSample('MadGraphResonanceMass300_width5', path='MadGraphChargedResonance_WGToLNuG_M300_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 300 GeV', XSName='ResonanceMass300')
     samples.AddSample('MadGraphResonanceMass350_width0p01', path='MadGraphChargedResonance_WGToLNuG_M350_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 350 GeV', XSName='ResonanceMass350')
@@ -223,7 +223,7 @@ def config_samples(samples) :
     samples.AddSample('MadGraphResonanceMass800_width5', path='MadGraphChargedResonance_WGToLNuG_M800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 800 GeV', XSName='ResonanceMass800')
     samples.AddSample('MadGraphResonanceMass900_width0p01', path='MadGraphChargedResonance_WGToLNuG_M900_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 900 GeV', XSName='ResonanceMass900')
     samples.AddSample('MadGraphResonanceMass900_width5', path='MadGraphChargedResonance_WGToLNuG_M900_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 900 GeV', XSName='ResonanceMass900')
-    samples.AddSample('MadGraphResonanceMass1000_width0p01', path='MadGraphChargedResonance_WGToLNuG_M1000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000')
+    samples.AddSample('MadGraphResonanceMass1000_width0p01', path='MadGraphChargedResonance_WGToLNuG_M1000_width0p01', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kPink+10, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000')#TODO: Active signal
     samples.AddSample('MadGraphResonanceMass1000_width5', path='MadGraphChargedResonance_WGToLNuG_M1000_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1000 GeV', XSName='ResonanceMass1000')
     samples.AddSample('MadGraphResonanceMass1200_width0p01', path='MadGraphChargedResonance_WGToLNuG_M1200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1200 GeV', XSName='ResonanceMass1200')
     samples.AddSample('MadGraphResonanceMass1200_width5', path='MadGraphChargedResonance_WGToLNuG_M1200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1200 GeV', XSName='ResonanceMass1200')
@@ -235,7 +235,7 @@ def config_samples(samples) :
     samples.AddSample('MadGraphResonanceMass1800_width5', path='MadGraphChargedResonance_WGToLNuG_M1800_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 1800 GeV', XSName='ResonanceMass1800')
     samples.AddSample('MadGraphResonanceMass2000_width0p01', path='MadGraphChargedResonance_WGToLNuG_M2000_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kGreen, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2000 GeV', XSName='ResonanceMass2000')
     samples.AddSample('MadGraphResonanceMass2000_width5', path='MadGraphChargedResonance_WGToLNuG_M2000_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2000 GeV', XSName='ResonanceMass2000')
-    samples.AddSample('MadGraphResonanceMass2200_width0p01', path='MadGraphChargedResonance_WGToLNuG_M2200_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2200 GeV', XSName='ResonanceMass2200')
+    samples.AddSample('MadGraphResonanceMass2200_width0p01', path='MadGraphChargedResonance_WGToLNuG_M2200_width0p01', isActive=True, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2200 GeV', XSName='ResonanceMass2200')#TODO: Active signal
     samples.AddSample('MadGraphResonanceMass2200_width5', path='MadGraphChargedResonance_WGToLNuG_M2200_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2200 GeV', XSName='ResonanceMass2200')
     samples.AddSample('MadGraphResonanceMass2400_width0p01', path='MadGraphChargedResonance_WGToLNuG_M2400_width0p01', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2400 GeV', XSName='ResonanceMass2400')
     samples.AddSample('MadGraphResonanceMass2400_width5', path='MadGraphChargedResonance_WGToLNuG_M2400_width5', isActive=False, isSignal=True, useXSFile=True, plotColor=ROOT.kRed, legend_name = '#Phi^{#pm} #rightarrow W^{#pm}#gamma, M = 2400 GeV', XSName='ResonanceMass2400')

--- a/Plotting/SampleManager.py
+++ b/Plotting/SampleManager.py
@@ -355,10 +355,10 @@ class Sample :
 class SampleFrame(object):
     """ Manage RDataFrame pointers """
 
-    def __init__(self, sampleptr=None, samplemanager=None):
+    def __init__(self, sampleptr=None, samplemanager=None, dataFrame=True):
         self.sampleptr = {}
-        self.triggered = False # prevent accidental triggering
         self.state = ""
+        self.dataFrame = dataFrame
         self.sm = samplemanager
 
     #--------------------------------
@@ -390,6 +390,9 @@ class SampleFrame(object):
 
     def SetHelper(self,filterexp,function,state=None):
         ## sentinel checks
+        if not self.dataFrame:
+            print "DataFrame not available"
+            return self
         if filterexp==None:
             print "noactions: empty string"
             return None
@@ -403,11 +406,15 @@ class SampleFrame(object):
             sf.sampleptr[s] = function(sp, filterexp)
         return sf
 
+    #--------------------------------
+
     def Draw(self, *arg):
         if self.state == "histo":
             self.sm.Draw(self,*arg)
         else:
             print "Not a Histo"
+
+    #--------------------------------
 
     def ShowCount(self, *arg):
         if self.state == "count":
@@ -434,7 +441,7 @@ class SampleManager(SampleFrame) :
         #
 
         # inheriting attribute and methods from SampleFrame
-        super(SampleManager,self).__init__(samplemanager=self)
+        super(SampleManager,self).__init__(samplemanager=self, dataFrame=dataFrame)
         self.state = "samplemanager"
 
         #
@@ -2341,7 +2348,10 @@ class SampleManager(SampleFrame) :
 
     #--------------------------------
 
-    def ShowCount(self, counter, dolatex=False, isActive=True, includeData=False, sort=True):
+    def ShowCount(self, counter=None, dolatex=False, isActive=True, includeData=False, sort=True):
+        if counter == None:
+            print "no counter"
+            return
         ## check that SampleFrame is passed
         if not isinstance(counter, SampleFrame) and counter.state == "count":
             return

--- a/Plotting/SampleManager.py
+++ b/Plotting/SampleManager.py
@@ -89,6 +89,9 @@ class Sample :
         # Should not be filled for a sample group
         self.chain = kwargs.get('chain', None)
 
+        # contain RDataFrame
+        self.rd    = None
+
         # link to the hosting sample manager
         self.manager = kwargs.get('manager', None)
 
@@ -213,7 +216,7 @@ class Sample :
             #self.hist.SetNdivisions(509, True )
 
 
-    def AddFiles( self, files, treeName=None, readHists=False , weightHistName=None) :
+    def AddFiles( self, files, treeName=None, readHists=False , weightHistName=None, dataFrame=False) :
         """ Add one or more files and grab the tree named treeName """
 
         if not isinstance(files, list) :
@@ -247,6 +250,10 @@ class Sample :
         if readHists:
             for f in files :
                 self.ofiles.append( f )
+
+        # make RDataFrame
+        if dataFrame:
+            self.rd = ROOT.RDataFrame(self.chain)
 
     def AddGroupSamples( self, samplenames ) :
         """ Add subsamples to this sample by samplenames"""
@@ -297,7 +304,7 @@ class SampleManager :
     """ Manage input samples and drawn histograms """
 
     def __init__(self, base_path, treeName=None, mcweight=1.0, treeNameModel='events', filename='ntuple.root',
-            base_path_model=None, xsFile=None, lumi=None, readHists=False, quiet=False, weightHistName = "weighthist") :
+            base_path_model=None, xsFile=None, lumi=None, readHists=False, dataFrame=False, quiet=False, weightHistName = "weighthist") :
 
         #
         # This plotting module assumes that root files are
@@ -390,6 +397,7 @@ class SampleManager :
 
         # read histograms instead of trees
         self.readHists = readHists
+        self.dataFrame = dataFrame
 
         self.quiet = quiet
 
@@ -1821,7 +1829,7 @@ class SampleManager :
                                 sigLineStyle=sigLineStyle, sigLineWidth=sigLineWidth, displayErrBand=displayErrBand,
                                 color=plotColor, drawRatio=drawRatio, scale=thisscale, lumi=self.lumi,  legendName=legend_name)
 
-            thisSample.AddFiles( input_files, self.treeName, self.readHists, self.weightHistName)
+            thisSample.AddFiles( input_files, self.treeName, self.readHists, self.weightHistName, self.dataFrame)
 
             self.samples.append(thisSample)
 
@@ -4368,3 +4376,9 @@ class SampleManager :
                 ibin = dest_hist.GetBin( xbin )
                 _add_generic_bin( dest_hist, add_hist, ibin )
 
+
+
+if __name__ == "__main__":
+    print "TEST SEQUENCE for RDataFrame"
+
+    

--- a/Plotting/SampleManager.py
+++ b/Plotting/SampleManager.py
@@ -3587,6 +3587,12 @@ class SampleManager :
             printline+= "\\hline\\hline\n%20s & %s\\\\\n" %result[-1]
             print printline
             return
+        self.print_stackresult(result)
+        return
+
+    def print_stackresult(self,result):
+        if isinstance(result, dict):
+            result = result.items()
 
         result = [ (r1,)+r2 for r1, r2 in result]
         totalresult = None

--- a/Plotting/SampleManager.py
+++ b/Plotting/SampleManager.py
@@ -380,7 +380,8 @@ class SampleFrame(object):
 
     def SetCount(self,weight=None):
         if weight:
-            return self.SetHelper(" "      ,lambda sp,exp: sp.Sum(weight), state = "count")
+            sqweight = "%s*%s" %(weight,weight)
+            return self.SetHelper(" "      ,lambda sp,exp: (sp.Sum(weight),sp.Define("sqw",sqweight).Sum("sqw")), state = "count")
         else:
             return self.SetHelper(" "      ,lambda sp,exp: sp.Count(), state = "count")
 
@@ -3052,12 +3053,20 @@ class SampleManager(SampleFrame) :
             return
 
         else :
-            ## retrieve the dataframe object by Sample
-            count = counter.sampleptr[sample].GetValue()
+            ## calculate the appropriate scaling
             if onthefly and not (sample.isData or sample.IsGroupedSample() or sample.name == "__AllStack__" or sample.isRatio==True):
                 scale = sample.scale_calc() 
             else: scale = sample.scale
-            sample.count = ufloat(count * scale, math.sqrt(count)*scale)
+            ## retrieve the dataframe object by Sample
+            #count = counter.sampleptr[sample].GetValue()
+            scounter = counter.sampleptr[sample]
+            if isinstance(scounter, tuple):
+                count = scounter[0].GetValue()
+                errsq = scounter[1].GetValue()
+            else:
+                count = scounter.GetValue()
+                errsq = count
+            sample.count = ufloat(count * scale, math.sqrt(errsq)*scale)
 
 
     #--------------------------------

--- a/Plotting/SampleManager.py
+++ b/Plotting/SampleManager.py
@@ -378,8 +378,11 @@ class SampleFrame(object):
 
     #--------------------------------
 
-    def SetCount(self):
-        return self.SetHelper(" "      ,lambda sp,exp: sp.Count(), state = "count")
+    def SetCount(self,weight=None):
+        if weight:
+            return self.SetHelper(" "      ,lambda sp,exp: sp.Sum(weight), state = "count")
+        else:
+            return self.SetHelper(" "      ,lambda sp,exp: sp.Count(), state = "count")
 
     #--------------------------------
 

--- a/Plotting/interactiveStackTree.py
+++ b/Plotting/interactiveStackTree.py
@@ -25,6 +25,7 @@ p.add_argument('--readHists',     default=False,action='store_true',   dest='rea
 
 p.add_argument('--quiet',     default=False,action='store_true',   dest='quiet',         help='disable information messages')
 p.add_argument('--jupyt',     default=False,action='store_true',   dest='jupyt',         help='use setting for jupyter notebook')
+p.add_argument('--nodataFrame', default=True,action='store_false',   dest='dataFrame',   help='backwards compatibility for pre-2019 releases of ROOT')
 p.add_argument('--batch',     default=False,action='store_true',   dest='batch',         help='use batch mode')
 p.add_argument('--reload',     default=False,action='store_true',   dest='reload',         help='reload sample manager')
 p.add_argument('--combine',     default=False,action='store_true',   dest='combine',         help='Combine years')
@@ -78,7 +79,7 @@ def main() :
             samplelist[year] = SampleManager(options.baseDir %year, options.treeName, mcweight=options.mcweight,
                         treeNameModel=options.treeNameModel, filename=options.fileName, base_path_model=options.baseDirModel,
                         xsFile=options.xsFile %year , lumi=lumi, readHists=options.readHists,
-                        quiet=options.quiet, weightHistName=options.weightHistName)
+                        quiet=options.quiet, weightHistName=options.weightHistName, dataFrame = options.dataFrame)
             samplelist[year].ReadSamples( options.samplesConf %year )
 
             if samples == None:  samples = samplelist[year]
@@ -87,7 +88,8 @@ def main() :
     else:
         samples = SampleManager(options.baseDir, options.treeName, mcweight=options.mcweight, treeNameModel=options.treeNameModel,
                                 filename=options.fileName, base_path_model=options.baseDirModel, xsFile=options.xsFile,
-                                lumi=options.lumi, readHists=options.readHists, quiet=options.quiet, weightHistName=options.weightHistName)
+                                lumi=options.lumi, readHists=options.readHists, quiet=options.quiet, 
+                                weightHistName=options.weightHistName, dataFrame = options.dataFrame)
 
 
         if options.samplesConf is not None :


### PR DESCRIPTION
Adapting our plotter to RDataFrame by adding SampleFrame class
SampleFrame is a simple wrapper that follows RDataFrame's functional programming paradigm
A SampleFrame object returns another SampleFrame after each application of a member method

SampleManager itself is a subclass of SampleFrame and natural origin of analysis

Tutorials for RDataFrame
https://root.cern.ch/doc/master/group__tutorial__dataframe.html

```
samples = SampleManager()
sf = samples.SetFilter("met_pt > 60.")  
sf = sf.SetDefine("phpt0","ph_pt[0]")
sf = sf.SetFilter("phpt0 > 50.")
sf = sf.SetHisto1D(("","",100,0,1000),"mt_lep_met_ph")
sf.Draw(hist_config=histo_config) # triggering loop
```
Note that one can skip the triggering method: Draw(), and continue to book other histograms.

The loop is only run once when triggered, so if 3 histograms are booked with different cuts. Data is looped over at the first Draw() command. The time running the three Draw()s are  15.22, 0.03, 0.009. The RDataFrame booking is identical in all samples contained in SampleFrame, but not all samples are necessarily triggered at Draw command (for example, if data is blinded or signal is set to inactive), so as to reduce unnecessarily computation. It also means that the same graph could be redrawn with different active components without re-running the loop.

Now supported method
```
SetFilter(*exp)
SetDefine(*exp)
SetHisto1D(*exp) # book histogram
SetCount() # book a count
GetValue() # triggering
Draw() # triggering; only works after Histo1D. Same argument as SampleManager.Draw() but selection and histpars are ignored
```