### PR TITLE
Fix issues with importing systematics pdf into datacard

### DIFF
--- a/Plotting/FitManager.py
+++ b/Plotting/FitManager.py
@@ -9,9 +9,8 @@ import sys
 from collections import namedtuple, OrderedDict
 from functools import wraps
 from DrawConfig import DrawConfig
-from pprint import pprint
 #gSystem.Load("My_double_CB/RooDoubleCB_cc.so")
-from ROOT import RooDoubleCB
+#from ROOT import RooDoubleCB
 
 
 ROOT.gStyle.SetPalette(ROOT.kBird)
@@ -1010,17 +1009,22 @@ class FitManager :
         #self.fit_params['cb'] = cb
 
     def shifted_dscb(self, workspace):
-        ## FIXME makeshift test for shifting mean of crystal ball
         self.wk = workspace
-        exprstr = "expr::cb_mass_{tag}_up('cb_mass_{tag}*cb_mass_{tag}_shift_up',"\
-                   "cb_mass_{tag},cb_mass_{tag}_shift_up[1.005])".format(tag=self.label) ##FIXME later
+
+        ## UP variation
+        exprstr = "expr::cb_mass_{tag}_UP('cb_mass_{tag}*cb_mass_{tag}_shift_UP',"\
+                   "cb_mass_{tag},cb_mass_{tag}_shift_UP[1.005])".format(tag=self.label)
         self.fact(exprstr)
-        self.fact("RooDoubleCB::cb_{tag}_up(mt_res,cb_mass_{tag}_up,cb_sigma_{tag},"
+
+        self.fact("RooDoubleCB::cb_{tag}_UP(mt_res,cb_mass_{tag}_UP,cb_sigma_{tag},"
               "cb_cut1_{tag},cb_power1_{tag}, cb_cut2_{tag}, cb_power2_{tag})".format(tag=self.label))
-        exprstr = "expr::cb_mass_{tag}_down('cb_mass_{tag}*cb_mass_{tag}_shift_down',"\
-                   "cb_mass_{tag},cb_mass_{tag}_shift_down[0.995])".format(tag=self.label) ##FIXME later
+
+        # DOWN variation
+        exprstr = "expr::cb_mass_{tag}_DN('cb_mass_{tag}*cb_mass_{tag}_shift_DN',"\
+                   "cb_mass_{tag},cb_mass_{tag}_shift_DN[0.995])".format(tag=self.label)
         self.fact(exprstr)
-        self.fact("RooDoubleCB::cb_{tag}_down(mt_res,cb_mass_{tag}_down,cb_sigma_{tag},"
+
+        self.fact("RooDoubleCB::cb_{tag}_DN(mt_res,cb_mass_{tag}_DN,cb_sigma_{tag},"
               "cb_cut1_{tag},cb_power1_{tag}, cb_cut2_{tag}, cb_power2_{tag})".format(tag=self.label))
         return
 

--- a/Plotting/Makefile
+++ b/Plotting/Makefile
@@ -85,21 +85,21 @@ sys:
 
 llvalid : 
 
-	python MakeMuValidPlot.py --batch --year 2016
-	python MakeMuValidPlot.py --batch --year 2017
-	python MakeMuValidPlot.py --batch --year 2018
-	python MakeEGValidPlot.py --batch --year 2016
-	python MakeEGValidPlot.py --batch --year 2017
-	python MakeEGValidPlot.py --batch --year 2018
+	python MakeMuValidPlot.py --batch --year 2016 --condor
+	python MakeMuValidPlot.py --batch --year 2017 --condor
+	python MakeMuValidPlot.py --batch --year 2018 --condor
+	python MakeEGValidPlot.py --batch --year 2016 --condor
+	python MakeEGValidPlot.py --batch --year 2017 --condor
+	python MakeEGValidPlot.py --batch --year 2018 --condor
 
 lgvalid : 
 
-	python MakeElGValidPlot.py --batch --year 2016
-	python MakeElGValidPlot.py --batch --year 2017
-	python MakeElGValidPlot.py --batch --year 2018
-	python MakeMuGValidPlot.py --batch --year 2016
-	python MakeMuGValidPlot.py --batch --year 2017
-	python MakeMuGValidPlot.py --batch --year 2018
+	python MakeElGValidPlot.py --batch --year 2016 --condor
+	python MakeElGValidPlot.py --batch --year 2017 --condor
+	python MakeElGValidPlot.py --batch --year 2018 --condor
+	python MakeMuGValidPlot.py --batch --year 2016 --condor
+	python MakeMuGValidPlot.py --batch --year 2017 --condor
+	python MakeMuGValidPlot.py --batch --year 2018 --condor
 
 money : 
 
@@ -109,9 +109,9 @@ money :
 
 signal : 
 
-	python MakeSignalWS.py --batch --year 2016
-	python MakeSignalWS.py --batch --year 2017
-	python MakeSignalWS.py --batch --year 2018
+	python MakeSignalWS.py --batch --condor --year 2016
+	python MakeSignalWS.py --batch --condor --year 2017
+	python MakeSignalWS.py --batch --condor --year 2018
 
 bkg : 
 


### PR DESCRIPTION
Shifts in mean parameter due to energy scale uncertainty in signal pdf is stored in json (The largest shift is chosen) and used to reconstruct the pdf later. This is a workaround for the erratic result that arises when three pdfs fitted separately are used in the HiggsCombine datacard

![Screen Shot 2021-08-06 at 17 02 34](https://user-images.githubusercontent.com/10662708/128572911-79b316f2-3ba3-4871-9097-635a5bddc79a.png)
