### PR TITLE
Recalculate PDF Scale Weights

### DIFF
--- a/Analysis/TreeFilter/Core/python/scheduler_base.py
+++ b/Analysis/TreeFilter/Core/python/scheduler_base.py
@@ -164,7 +164,7 @@ def RunJobs( jobs, configs, options, dry_run=False ) :
 
                 if PUPath is not None :
 
-                    module_str += '\'sampleFile\' : \'%s/%s/hist.root\', ' %( PUPath, job.sample )
+                    module_str += '\'sampleFile\' : \'%s/%s_hist.root\', ' %( PUPath, job.sample )
 
                 module_str += '}'
 

--- a/Analysis/TreeFilter/RecoResonance/include/RunAnalysis.h
+++ b/Analysis/TreeFilter/RecoResonance/include/RunAnalysis.h
@@ -103,8 +103,9 @@ class RunModule : public virtual RunModuleBase {
 
         TFile * _puweight_sample_file;
         TFile * _puweight_data_file;
-        TH1F * _puweight_sample_hist;
+        TH1D * _puweight_sample_hist;
         TH1D * _puweight_data_hist;
+        TH1D * _pdfweight_sample_hist;
         TH1D * h_EventWeight;
 
 	RoccoR rc;

--- a/Analysis/TreeFilter/RecoResonance/scripts/Conf2016.py
+++ b/Analysis/TreeFilter/RecoResonance/scripts/Conf2016.py
@@ -952,7 +952,8 @@ def weight_event( args ) :
         filt.add_var( 'sample_file', args['sampleFile'])
         filt.add_var( 'data_file', '%s/TreeFilter/RecoResonance/data/DataPileupHistogram2016.root' %workarea )
         filt.add_var( 'sample_hist', 'pileup_true' )
-        filt.add_var('data_hist', 'pileup')
+        filt.add_var( 'data_hist', 'pileup')
+        filt.add_var( 'pdf_hist', 'pdfscale')
     else :
         print 'weight_event requires as a command line argument like --moduleArgs " { \'sampleFile\' : \'/path/histograms.root\'} "'
 

--- a/Analysis/TreeFilter/RecoResonance/scripts/Conf2017.py
+++ b/Analysis/TreeFilter/RecoResonance/scripts/Conf2017.py
@@ -953,7 +953,8 @@ def weight_event( args ) :
         filt.add_var( 'sample_file', args['sampleFile'])
         filt.add_var( 'data_file', '%s/TreeFilter/RecoResonance/data/DataPileupHistogram2017.root' %workarea )
         filt.add_var( 'sample_hist', 'pileup_true' )
-        filt.add_var('data_hist', 'pileup')
+        filt.add_var( 'data_hist', 'pileup')
+        filt.add_var( 'pdf_hist', 'pdfscale')
     else :
         print 'weight_event requires as a command line argument like --moduleArgs " { \'sampleFile\' : \'/path/histograms.root\'} "'
 

--- a/Analysis/TreeFilter/RecoResonance/scripts/Conf2018.py
+++ b/Analysis/TreeFilter/RecoResonance/scripts/Conf2018.py
@@ -952,7 +952,8 @@ def weight_event( args ) :
         filt.add_var( 'sample_file', args['sampleFile'])
         filt.add_var( 'data_file', '%s/TreeFilter/RecoResonance/data/DataPileupHistogram2018.root' %workarea )
         filt.add_var( 'sample_hist', 'pileup_true' )
-        filt.add_var('data_hist', 'pileup')
+        filt.add_var( 'data_hist', 'pileup')
+        filt.add_var( 'pdf_hist', 'pdfscale')
     else :
         print 'weight_event requires as a command line argument like --moduleArgs " { \'sampleFile\' : \'/path/histograms.root\'} "'
 

--- a/Analysis/TreeFilter/RecoResonance/src/RunAnalysis.cxx
+++ b/Analysis/TreeFilter/RecoResonance/src/RunAnalysis.cxx
@@ -976,7 +976,7 @@ bool RunModule::execute( std::vector<ModuleConfig> & configs ) {
     // loop over configured modules
     bool save_event = true;
     printevent = false;
-    if( IN::eventNumber%1000000 == 42 ) printevent = true;
+    if( IN::eventNumber%10000 == 42 ) printevent = true;
     if( printevent ) std::cout << " eventNumber " << IN::eventNumber << std::endl;
     BOOST_FOREACH( ModuleConfig & mod_conf, configs ) {
         save_event &= ApplyModule( mod_conf );
@@ -4671,7 +4671,7 @@ void RunModule::WeightEvent( ModuleConfig & config ) const {
       OUT::PDFWeights->clear();
       //for (int i = 1; i<10; i++){
       for ( int i : { 1, 2, 3, 4, 6, 8 } ){
-        std::cout<<i<<"  "
+        if (printevent) std::cout<<i<<"  "
         <<(IN::EventWeights->at(i)/IN::EventWeights->at(0)/_pdfweight_sample_hist->GetBinContent(i+1))<<" "
         <<IN::EventWeights->at(i)/IN::EventWeights->at(0)<<"  "<<_pdfweight_sample_hist->GetBinContent(i+1)<<std::endl;
         OUT::PDFWeights->push_back(IN::EventWeights->at(i)/IN::EventWeights->at(0)/_pdfweight_sample_hist->GetBinContent(i+1));

--- a/Analysis/Util/scripts/make_pileup_histos.py
+++ b/Analysis/Util/scripts/make_pileup_histos.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import ROOT
+import time
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 ROOT.gROOT.SetBatch(True)
 
@@ -8,65 +9,109 @@ from argparse import ArgumentParser
 
 parser = ArgumentParser()
 
-#parser.add_argument('--version', dest='version', required=True, help='Name of version directory (Resonances_v10)' )
-#parser.add_argument('--outputDir', dest='outputDir', required=True, help='output path' )
+parser.add_argument('--version', dest='version', help='Name of version directory' )
+parser.add_argument('--outputDir', dest='outputDir', required=False, default=None, help='output path' )
 parser.add_argument('--fileKey', dest='fileKey', default=None, help='key to match files' )
 parser.add_argument('--treeName', dest='treeName', default='UMDNTuple/EventTree', help='tree name' )
 parser.add_argument('--skipDone', dest='skipDone', default=False, action = "store_true", help='skip pileup histograms already made' )
+parser.add_argument('--year', dest='year', default=2016, type=int, help='set run year' )
+parser.add_argument('--sample', dest='mcsample', default='', help='specify sample to run on' )
+parser.add_argument('--quick', dest='quick', action = "store_true", help='run the first 3e6 events for quick result' )
+parser.add_argument('--condor', dest='condor', action = "store_true", help='submit condor jobs' )
+parser.add_argument('--dryrun', dest='dryrun', action = "store_true", help='produce job description but not submit job' )
 
 options = parser.parse_args()
 
 _NTUPLE_DIR = '/store/group/WGAMMA/'
-options.version = 'UMDNTuple_0902'
-options.outputDir = '/data2/users/kakw/Resonances2016/pileup/'
+if not options.version:
+    options.version = 'UMDNTuple_0902'
+if options.outputDir is None:
+    options.outputDir = '/data2/users/kakw/Resonances%i/pileup/' %options.year
+
+
+
+mc_samples = [] # empty list means run over all found subdirectories
+
+#mc_samples = ['MadGraphChargedResonance_WGToLNu_M1000_width0p01',
+#              'MadGraphChargedResonance_WGToLNu_M350_width0p01',
+#              'MadGraphChargedResonance_WGToLNu_M500_width5',
+#              ]
+
+if options.mcsample: mc_samples = [options.mcsample,]
+
+# Data samples are skipped
+data_samples = ['SingleElectron', 'SingleMuon', 'SinglePhoton', 'DoubleMuon', 'DoubleElectron', 'EGamma']
+
+
+
+
+### ------------- main function -----------------
+
+
 
 def main() :
 
-    #mc_samples = [] # empty list means run over all found subdirectories
-    mc_samples = [#'MadGraphChargedResonance_WGToLNuG_M1000_width0p01',
-                  #'MadGraphChargedResonance_WGToLNuG_M350_width0p01',
-                  #'MadGraphChargedResonance_WGToLNuG_M500_width5',
-                  'MadGraphChargedResonance_WGToLNu_M2800_width5'
-                  ] # empty list means run over all found subdirectories
-    data_samples = ['SingleElectron', 'SingleMuon', 'SinglePhoton', 'DoubleMuon', 'DoubleElectron', 'EGamma']
-
+    ## if mc_samples is empty, we start by looking for samples
     if not mc_samples:
-        for samp in os.listdir( _NTUPLE_DIR ) :
-
-            if samp in data_samples :
-                continue
-
-            if options.skipDone and os.path.isfile( '%s/%s/hist.root' %( options.outputDir, samp ) ) :
-                continue
-
-            if os.path.isdir( '%s/%s/%s' %( _NTUPLE_DIR, samp, options.version ) ) :
-                mc_samples.append( samp )
+        samples = findsamples()
+    else:
+        samples = mc_samples
 
     for samp in mc_samples :
 
         samp_files = []
 
-        for top, dirs, files in os.walk( _NTUPLE_DIR + '/' + samp + '/' + options.version ,followlinks=True) :
+        for top, dirs, files in os.walk( ntuplepath(_NTUPLE_DIR, samp, options.version, options.year) ,followlinks=True) :
             for f in files :
                 if options.fileKey is None or f.count( options.fileKey ) > 0 :
                     samp_files.append('%s/%s' %(top, f ) )
 
-        samp_dir = '%s/%s' %( options.outputDir, samp )
+        if not os.path.isdir( options.outputDir ) :
+            os.makedirs( options.outputDir )
 
-        if not os.path.isdir(samp_dir ) :
-            os.makedirs( samp_dir )
-
-        if options.skipDone and os.path.isfile('%s/hist.root' %samp_dir):
+        if checkskipdone(samp):
             continue
-        outfile = ROOT.TFile.Open( '%s/hist.root' %samp_dir , 'RECREATE' )
+
+        outfile = ROOT.TFile.Open( '%s/%s_hist.root' %(options.outputDir, samp) , 'RECREATE' )
 
         print 'Make histogram for %s' %samp
-
+        timer= time.time()
 
         if samp_files: get_histograms( samp_files, outfile )
 
+        print "time: ", time.time()-timer
+
         outfile.Close()
 
+
+def ntuplepath( ntupledir, samp, vers, year ):
+    return "%s/%s/%s_%i" %( ntupledir, samp, vers, year )
+
+
+def findsamples():
+    samples = []
+    for samp in os.listdir( _NTUPLE_DIR ) :
+
+        if samp in data_samples :
+            continue
+
+        if checkskipdone(samp):
+            continue
+
+        if os.path.isdir(ntuplepath(_NTUPLE_DIR, samp, options.version, options.year)):
+            samples.append( samp )
+    return samples
+
+
+def checkskipdone(samp):
+    if options.skipDone and os.path.isfile( '%s/%s_hist.root' %( options.outputDir, samp ) ):
+        f=ROOT.TFile("%s/%s_hist.root" %(options.outputDir, samp))
+        h1 = f.Get("pileup_true")
+        h2 = f.Get("pdfscale")
+        if h1 and h2:
+            print "Done, and skip: ", samp
+            return True
+    return False
 
 def get_histograms(files, outfile) :
 
@@ -82,17 +127,93 @@ def get_histograms(files, outfile) :
     chain.SetBranchStatus('EventWeights', 1)
 
     outfile.cd()
-    chain.Draw( '%s >> pileup_true(100,0,100)' %branch_name, '1 * ( EventWeights[0] > 0 ) - 1* ( EventWeights[0] < 0 ) ' )
-    #chain.Draw( '%s >> pileup_true(100,0,100)' %branch_name, '' )
 
-    hist = outfile.Get('pileup_true')
+    histpu = ROOT.TH1D("pileup_true","Pile up histogram", 100, 0, 100)
 
-    hist.Write()
+    if options.quick:
+        chain.Draw( '%s >> pileup_true' %branch_name, '1 * ( EventWeights[0] > 0 ) - 1* ( EventWeights[0] < 0 ) ', '', 3000000 )
+    else:
+        chain.Draw( '%s >> pileup_true' %branch_name, '1 * ( EventWeights[0] > 0 ) - 1* ( EventWeights[0] < 0 ) ' )
+
+    histpu.Write()
+
+
+    ## Make histogram for PDF Scale weights
+    histpdf = ROOT.TH1D("pdfscale","PDF Scale Weights", 100, 0, 100)
+
+    if options.quick:
+        chain.Draw( "Iteration$>>pdfscale", "EventWeights[]/EventWeights[0]", "", 3000000)
+    else:
+        chain.Draw( "Iteration$>>pdfscale", "EventWeights[]/EventWeights[0]")
+
+    histpdf.Scale(1./chain.GetEntries())
+
+    histpdf.Write()
+
+
+
+def submitjobs():
+
+    desc_entries = [
+        "universe = vanilla",
+        "notify_user = kakw@umd.edu",
+        "notification = Error",
+        "getenv = True",
+#        "MINUTE      = 60",
+#        "periodic_hold = (CurrentTime - JobCurrentStartDate) >= 600 * $(MINUTE)",
+#        "periodic_release = NumJobStarts<5",
+        "Executable = make_pileup_histos.py", ]
+
+    if not mc_samples:
+        samples = findsamples()
+    else:
+        samples = mc_samples
+
+    for samp in samples:
+       makecondorjob(samp, desc_entries)
+
+    if not os.path.isdir( "logs" ) :
+       os.makedirs( "logs" )
+
+    submitcondorjob(desc_entries)
+
+
+def makecondorjob(samp,desc_entries):
+    """ this function modifies desc_entries
+        note the unconventional behavior
+    """
+    tag = "%s_%s_%i" %(samp, options.version, options.year)
+    addtl = ""
+    if options.quick:
+        addtl+="  --quick"
+    if options.skipDone:
+        addtl+="  --skipDone"
+
+    desc_entries+=[
+        "",
+        "output = logs/stdout$(cluster)_$(process)_%s.txt" %tag,
+        "error = logs/stderr$(cluster)_$(process)_%s.txt" %tag,
+        "log = logs/condor$(cluster)_$(process)_%s.txt" %tag,
+        "arguments = --sample %s --year %i %s" %(samp, options.year, addtl),
+        "queue",
+        ]
+
+
+def submitcondorjob(desc_entries):
+    print "\n".join(desc_entries)
+    desc_name = 'job_desc_make_pileup_histos.txt'
+    descf = open(desc_name, 'w')
+    descf.write('\n'.join(desc_entries))
+    descf.close()
+    if not options.dryrun: os.system('condor_submit %s ' % desc_name)
 
 
 
 
 
 
-main()
+if options.condor:
+    submitjobs()
+else:
+    main()
 

--- a/Analysis/Util/scripts/make_pileup_histos.py
+++ b/Analysis/Util/scripts/make_pileup_histos.py
@@ -23,6 +23,7 @@ parser.add_argument('--dryrun', dest='dryrun', action = "store_true", help='prod
 options = parser.parse_args()
 
 _NTUPLE_DIR = '/store/group/WGAMMA/'
+_QUICKNMAX = 1000000
 if not options.version:
     options.version = 'UMDNTuple_0902'
 if options.outputDir is None:
@@ -131,7 +132,7 @@ def get_histograms(files, outfile) :
     histpu = ROOT.TH1D("pileup_true","Pile up histogram", 100, 0, 100)
 
     if options.quick:
-        chain.Draw( '%s >> pileup_true' %branch_name, '1 * ( EventWeights[0] > 0 ) - 1* ( EventWeights[0] < 0 ) ', '', 3000000 )
+        chain.Draw( '%s >> pileup_true' %branch_name, '1 * ( EventWeights[0] > 0 ) - 1* ( EventWeights[0] < 0 ) ', '', _QUICKNMAX)
     else:
         chain.Draw( '%s >> pileup_true' %branch_name, '1 * ( EventWeights[0] > 0 ) - 1* ( EventWeights[0] < 0 ) ' )
 
@@ -142,11 +143,14 @@ def get_histograms(files, outfile) :
     histpdf = ROOT.TH1D("pdfscale","PDF Scale Weights", 100, 0, 100)
 
     if options.quick:
-        chain.Draw( "Iteration$>>pdfscale", "EventWeights[]/EventWeights[0]", "", 3000000)
+        chain.Draw( "Iteration$>>pdfscale", "EventWeights[]/EventWeights[0]", "",  _QUICKNMAX)
     else:
         chain.Draw( "Iteration$>>pdfscale", "EventWeights[]/EventWeights[0]")
 
-    histpdf.Scale(1./chain.GetEntries())
+    if options.quick:
+        histpdf.Scale(1./_QUICKNMAX)
+    else:
+        histpdf.Scale(1./chain.GetEntries())
 
     histpdf.Write()
 

--- a/Plotting/Modules/Resonance2016.py
+++ b/Plotting/Modules/Resonance2016.py
@@ -5,7 +5,7 @@ def config_samples(samples) :
     samples.AddSample('SingleMuon'                       , path='SingleMuon'    ,  isActive=False, isData = True)
     samples.AddSample('SingleElectron'                       , path='SingleElectron'    ,  isActive=False, isData = True)
 
-    samples.AddSample('DYJetsToLL_M-50',
+    samples.AddSample('DYJetsToLL_M-50_LO',
                       path='DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8PhOlap',
                       isActive=False, useXSFile=True )
 
@@ -373,7 +373,7 @@ def config_samples(samples) :
                           )
 
     samples.AddSampleGroup(  'ZJetsLO', legend_name='Z+JetsLO',
-                           input_samples = ['DYJetsToLL_M-50'],
+                           input_samples = ['DYJetsToLL_M-50_LO'],
                            plotColor = ROOT.kCyan-2,
                            isActive=False,
                           )

--- a/Plotting/Modules/Resonance2017.py
+++ b/Plotting/Modules/Resonance2017.py
@@ -5,9 +5,8 @@ def config_samples(samples) :
     samples.AddSample('SingleMuon'                       , path='SingleMuon'    ,  isActive=False, isData = True)
     samples.AddSample('SingleElectron'                       , path='SingleElectron'    ,  isActive=False, isData = True)
 
-    samples.AddSample('DYJetsToLL_M-50',
+    samples.AddSample('DYJetsToLL_M-50_LO',
                       path='DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8PhOlap',
-		              #path='DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8',
                       isActive=False, useXSFile=True )
 
     samples.AddSample('DYJetsToLL_M-50-amcatnloFXFXPhOlap',
@@ -332,7 +331,7 @@ def config_samples(samples) :
                           )
 
     samples.AddSampleGroup(  'ZJetsLO', legend_name='Z+JetsLO',
-                           input_samples = ['DYJetsToLL_M-50'],
+                           input_samples = ['DYJetsToLL_M-50_LO'],
                            plotColor = ROOT.kCyan-2,
                            isActive=False,
                           )

--- a/Plotting/Modules/Resonance2018.py
+++ b/Plotting/Modules/Resonance2018.py
@@ -5,7 +5,7 @@ def config_samples(samples) :
     samples.AddSample('SingleMuon'                       , path='SingleMuon'    ,  isActive=False, isData = True)
     samples.AddSample('EGamma'                       , path='EGamma'    ,  isActive=False, isData = True)
 
-    samples.AddSample('DYJetsToLL_M-50',
+    samples.AddSample('DYJetsToLL_M-50_LO',
                       path='DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8PhOlap',
                       isActive=False, useXSFile=True )
 
@@ -323,7 +323,7 @@ def config_samples(samples) :
                           )
 
     samples.AddSampleGroup(  'ZJetsLO', legend_name='Z+JetsLO',
-                           input_samples = ['DYJetsToLL_M-50'],
+                           input_samples = ['DYJetsToLL_M-50_LO'],
                            plotColor = ROOT.kCyan-2,
                            isActive=False,
                           )

--- a/Plotting/SampleManager.py
+++ b/Plotting/SampleManager.py
@@ -4453,6 +4453,8 @@ class SampleManager(SampleFrame) :
             for samp in sighists :
                 if samp.isActive :
                     ## normalize signal samples
+                    if samp.hist.Integral()==0:
+                        break
                     if normalize == "Total":
                         samp.hist.Scale(1./samp.hist.GetBinContent(1))
                     elif normalize :


### PR DESCRIPTION
Weighted mean of PDF Scale is calculated in make_pileup_histos.py, then used to normalize PDFWeights branch
Now PDFWeights effectively calculates change in acceptance.

In make_pileup_histos.py, a quick mode is adopted (with the flag `--quick`) to run over only the first 1e6-1e7 of entries, as I/O severely limits speed of completion. For our purpose the precision is more than enough. (0.01%)