### PR TITLE
Fix experimental uncertainties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ CMSSW_*/
 log/
 plots/
 uncertainties-3.0.1/
+Analysis/Util/scripts/logs/
+Plotting/data

--- a/Plotting/MakeFits.py
+++ b/Plotting/MakeFits.py
@@ -635,8 +635,6 @@ class MakeLimits( ) :
         muennames  = ( 'MuonEnUp',       'MuonEnDown'  )
         elennames  = ( 'ElectronEnUp',   'ElectronEnDown')
         phennames  = ( 'PhotonEnUp',     'PhotonEnDown' )
-        elptnames  = ( 'ElectronPtScaleUp',   'ElectronPtScaleDown')
-        phptnames  = ( 'PhotonPtScaleUp',   'PhotonPtScaleDown' )
 
 
         newsysdict = recdd()
@@ -698,13 +696,6 @@ class MakeLimits( ) :
         ## el scale
         if ch == "el":
             newsysdict["CMS_el_scale"]  = tuple(sysdict[s]/100.+1 for s in elennames)
-
-        ## ph pt scale
-        #newsysdict["CMS_phpt_scale"]  = tuple(sysdict[s]/100.+1 for s in phptnames)
-
-        ## el pt scale
-        #if ch == "el":
-        #    newsysdict["CMS_elpt_scale"]  = tuple(sysdict[s]/100.+1 for s in elptnames)
 
         ## prefiring
         newsysdict["CMS_pref"]  = tuple(sysdict[s]/100.+1 for s in prefnames)

--- a/Plotting/MakeSignalWS.py
+++ b/Plotting/MakeSignalWS.py
@@ -13,6 +13,7 @@ execfile("MakeBase.py")
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 ROOT.Math.MinimizerOptions.SetDefaultMaxFunctionCalls( 100000)
 ROOT.gSystem.Load('My_double_CB/RooDoubleCB_cc.so')
+ROOT.gROOT.SetBatch()
 
 _XMIN_M = 0
 _XMAX_M = 4000
@@ -322,8 +323,6 @@ metlist=[
             "ElectronEn",
             "PhotonEn",
             "UnclusteredEn", #--/Up/Down
-            "PhotonPtScale",
-            "ElectronPtScale",
         ]
 
 eventweightlist = ["muR1muF2",
@@ -391,23 +390,27 @@ def make_syssellist( varnorm, selnorm, weightnorm, ch = "el"):
 
         w = weightnorm.replace("mt_res", "mt_res_%s" %tag )\
                   .replace("met_pt", "met_%s_pt" %tag )
-        sel = selnorm.replace("mt_res", "mt_res_%s" % tag )\
-                     .replace("met_pt", "met_%s_pt" % tag )
+        sel = selnorm.replace("mt_res", "mt_res_%s" % tag )
+        
+        if any(x in tag for x in ['Muon', 'Electron', 'Photon']):
+            sel = sel.replace("met_pt", "met_%sByHand_pt" % tag )
+        else:
+            sel = sel.replace("met_pt", "met_%s_pt" % tag )
 
         if tag == "MuonEnUp":
             sel = sel.replace("mu_pt_rc", "mu_pt_rc_up")
         if tag == "MuonEnDown":
             sel = sel.replace("mu_pt_rc", "mu_pt_rc_down")
 
-        if tag == "PhotonPtScaleUp":
-            sel = sel.replace("ph_pt", "ph_pt_Scale_up")
-        if tag == "PhotonPtScaleDown":
-            sel = sel.replace("ph_pt", "ph_pt_Scale_down")
+        if tag == "PhotonEnUp":
+            sel = sel.replace("ph_pt", "ph_pt_ScaleUp")
+        if tag == "PhotonEnDown":
+            sel = sel.replace("ph_pt", "ph_pt_ScaleDown")
 
-        if tag == "ElectronPtScaleUp":
-            sel = sel.replace("el_pt", "el_pt_Scale_up")
-        if tag == "ElectronPtScaleDown":
-            sel = sel.replace("el_pt", "el_pt_Scale_down")
+        if tag == "ElectronEnUp":
+            sel = sel.replace("el_pt", "el_pt_ScaleUp")
+        if tag == "ElectronEnDown":
+            sel = sel.replace("el_pt", "el_pt_ScaleDown")
 
         var = "mt_res_%s" %tag
         selection_list[tag] = (var, sel, w)


### PR DESCRIPTION
* Use shifts on MET calculated from object uncertainties
* Correlate MT, MET, and electron/pgoton/muon variation in the selection

Energy shifts for M=2000:
```
Systematics Name                Mean(GeV)      Shift Shift %%  Sig shift Shift %%
norm                               1929.0        0.0    0.0%        0.0      0%
mean_JetResUp                      1929.5        0.5    0.0%        0.0      0%
mean_JetResDown                    1929.1        0.1    0.0%        0.0      0%
mean_JetEnUp                       1929.1        0.1    0.0%        0.0      0%
mean_JetEnDown                     1928.9       -0.1   -0.0%        0.0      0%
mean_MuonEnUp                      1929.0       -0.0   -0.0%        0.0      0%
mean_MuonEnDown                    1929.0       -0.0   -0.0%        0.0      0%
mean_ElectronEnUp                  1929.5        0.5    0.0%        0.0      0%
mean_ElectronEnDown                1928.7       -0.3   -0.0%        0.0      0%
mean_PhotonEnUp                    1949.7       20.7    1.1%        0.0      0%
mean_PhotonEnDown                  1907.6      -21.4   -1.1%        0.0      0%
mean_UnclusteredEnUp               1931.8        2.7    0.1%        0.0      0%
mean_UnclusteredEnDown             1926.2       -2.8   -0.1%        0.0      0%
Max                                1949.7       20.7    1.1%
Min                                1907.6      -21.4   -1.1%
```